### PR TITLE
fix: resolve TypeScript duplicate identifier error in TikTok video type

### DIFF
--- a/src/types/creator-search.ts
+++ b/src/types/creator-search.ts
@@ -159,7 +159,6 @@ export interface ApifyTikTokVideo {
   id: string;
   text?: string;
   createTime?: number;
-  videoUrl?: string;
   authorMeta?: {
     id: string;
     name?: string;
@@ -198,6 +197,11 @@ export interface ApifyTikTokVideo {
     name?: string;
     title?: string;
   }>;
+  // Additional thumbnail URL fields that might be present
+  coverMediumUrl?: string;
+  coverLargeUrl?: string;
+  coverUrl?: string;
+  thumbnailUrl?: string;
 }
 
 export interface ApifyTikTokProfile {


### PR DESCRIPTION
- Remove duplicate videoUrl property
- Add missing thumbnail URL properties for TikTok videos

🤖 Generated with [Claude Code](https://claude.ai/code)

## 📋 Description
Brief description of changes made.

## 🔧 Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation update
- [ ] 🎨 UI/Canvas improvement

## ✅ Testing
- [ ] Tested locally in development
- [ ] Canvas functionality works
- [ ] No console errors
- [ ] Mobile responsive (if UI changes)

## 📸 Screenshots (if applicable)
Add screenshots of your changes, especially for UI updates.

## 📋 Checklist
- [ ] Code follows existing patterns
- [ ] TypeScript types are correct
- [ ] No sensitive data committed
- [ ] Self-review completed
